### PR TITLE
Add iSH Compatibility for running the client on iOS

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -128,6 +128,24 @@ func (lc stdListenConfig) ListenPacket(ctx context.Context, network, address str
 	return lc.ListenConfig.ListenPacket(ctx, network, address)
 }
 
+func closeWithLog(closer io.Closer, msg string) {
+	if err := closer.Close(); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
+func setDeadlineWithLog(conn interface{ SetDeadline(time.Time) error }, t time.Time, msg string) {
+	if err := conn.SetDeadline(t); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
+func setReadDeadlineWithLog(conn interface{ SetReadDeadline(time.Time) error }, t time.Time, msg string) {
+	if err := conn.SetReadDeadline(t); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
 func getVkCreds(link string) (string, string, string, error) {
 	doRequest := func(data string, url string) (resp map[string]interface{}, err error) {
 		client := &http.Client{
@@ -151,7 +169,7 @@ func getVkCreds(link string) (string, string, string, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer httpResp.Body.Close()
+		defer closeWithLog(httpResp.Body, "failed to close response body")
 
 		body, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -382,7 +400,7 @@ func getYandexCreds(link string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	defer resp.Body.Close()
+	defer closeWithLog(resp.Body, "failed to close conference response body")
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return "", "", "", fmt.Errorf("GetConference: status=%s body=%s", resp.Status, string(body))
@@ -410,7 +428,7 @@ func getYandexCreds(link string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", fmt.Errorf("ws dial: %w", err)
 	}
-	defer conn.Close()
+	defer closeWithLog(conn, "failed to close websocket connection")
 
 	req1 := HelloRequest{
 		UID: uuid.New().String(),
@@ -482,7 +500,7 @@ func getYandexCreds(link string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("ws write: %w", err)
 	}
 
-	conn.SetReadDeadline(time.Now().Add(15 * time.Second))
+	setReadDeadlineWithLog(conn, time.Now().Add(15*time.Second), "failed to set websocket read deadline")
 
 	for {
 		_, msg, err := conn.ReadMessage()
@@ -590,8 +608,8 @@ func oneDtlsConnection(ctx context.Context, peer *net.UDPAddr, listenConn net.Pa
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	context.AfterFunc(dtlsctx, func() {
-		listenConn.SetDeadline(time.Now())
-		dtlsConn.SetDeadline(time.Now())
+		setDeadlineWithLog(listenConn, time.Now(), "failed to set listener deadline")
+		setDeadlineWithLog(dtlsConn, time.Now(), "failed to set DTLS deadline")
 	})
 	var addr atomic.Value
 	// Start read-loop on listenConn
@@ -652,8 +670,8 @@ func oneDtlsConnection(ctx context.Context, peer *net.UDPAddr, listenConn net.Pa
 	}()
 
 	wg.Wait()
-	listenConn.SetDeadline(time.Time{})
-	dtlsConn.SetDeadline(time.Time{})
+	setDeadlineWithLog(listenConn, time.Time{}, "failed to clear listener deadline")
+	setDeadlineWithLog(dtlsConn, time.Time{}, "failed to clear DTLS deadline")
 }
 
 type connectedUDPConn struct {
@@ -788,8 +806,8 @@ func oneTurnConnection(ctx context.Context, turnParams *turnParams, peer *net.UD
 	wg.Add(2)
 	turnctx, turncancel := context.WithCancel(context.Background())
 	context.AfterFunc(turnctx, func() {
-		relayConn.SetDeadline(time.Now())
-		conn2.SetDeadline(time.Now())
+		setDeadlineWithLog(relayConn, time.Now(), "failed to set relay deadline")
+		setDeadlineWithLog(conn2, time.Now(), "failed to set TURN peer deadline")
 	})
 	var addr atomic.Value
 	// Start read-loop on conn2 (output of DTLS)
@@ -850,8 +868,8 @@ func oneTurnConnection(ctx context.Context, turnParams *turnParams, peer *net.UD
 	}()
 
 	wg.Wait()
-	relayConn.SetDeadline(time.Time{})
-	conn2.SetDeadline(time.Time{})
+	setDeadlineWithLog(relayConn, time.Time{}, "failed to clear relay deadline")
+	setDeadlineWithLog(conn2, time.Time{}, "failed to clear TURN peer deadline")
 }
 
 func oneDtlsConnectionLoop(ctx context.Context, peer *net.UDPAddr, listenConnChan <-chan net.PacketConn, connchan chan<- net.PacketConn, okchan chan<- struct{}) {

--- a/server/main.go
+++ b/server/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -16,6 +17,30 @@ import (
 	"github.com/pion/dtls/v3"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 )
+
+func closeWithLog(closer io.Closer, msg string) {
+	if err := closer.Close(); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
+func setDeadlineWithLog(conn interface{ SetDeadline(time.Time) error }, t time.Time, msg string) {
+	if err := conn.SetDeadline(t); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
+func setReadDeadlineWithLog(conn interface{ SetReadDeadline(time.Time) error }, t time.Time, msg string) {
+	if err := conn.SetReadDeadline(t); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
+
+func setWriteDeadlineWithLog(conn interface{ SetWriteDeadline(time.Time) error }, t time.Time, msg string) {
+	if err := conn.SetWriteDeadline(t); err != nil {
+		log.Printf("%s: %v", msg, err)
+	}
+}
 
 func main() {
 	listen := flag.String("listen", "0.0.0.0:56000", "listen on ip:port")
@@ -89,7 +114,7 @@ func main() {
 		wg1.Add(1)
 		go func(conn net.Conn) {
 			defer wg1.Done()
-			defer conn.Close() // graceful shutdown
+			defer closeWithLog(conn, "failed to close incoming connection")
 			var err error = nil
 			log.Printf("Connection from %s\n", conn.RemoteAddr())
 			// `conn` is of type `net.Conn` but may be casted to `dtls.Conn`
@@ -129,8 +154,8 @@ func main() {
 			wg.Add(2)
 			ctx2, cancel2 := context.WithCancel(ctx)
 			context.AfterFunc(ctx2, func() {
-				conn.SetDeadline(time.Now())
-				serverConn.SetDeadline(time.Now())
+				setDeadlineWithLog(conn, time.Now(), "failed to set incoming deadline")
+				setDeadlineWithLog(serverConn, time.Now(), "failed to set outgoing deadline")
 			})
 			go func() {
 				defer wg.Done()
@@ -142,14 +167,14 @@ func main() {
 						return
 					default:
 					}
-					conn.SetReadDeadline(time.Now().Add(time.Minute * 30))
+					setReadDeadlineWithLog(conn, time.Now().Add(30*time.Minute), "failed to set incoming read deadline")
 					n, err1 := conn.Read(buf)
 					if err1 != nil {
 						log.Printf("Failed: %s", err1)
 						return
 					}
 
-					serverConn.SetWriteDeadline(time.Now().Add(time.Minute * 30))
+					setWriteDeadlineWithLog(serverConn, time.Now().Add(30*time.Minute), "failed to set outgoing write deadline")
 					_, err1 = serverConn.Write(buf[:n])
 					if err1 != nil {
 						log.Printf("Failed: %s", err1)
@@ -167,14 +192,14 @@ func main() {
 						return
 					default:
 					}
-					serverConn.SetReadDeadline(time.Now().Add(time.Minute * 30))
+					setReadDeadlineWithLog(serverConn, time.Now().Add(30*time.Minute), "failed to set outgoing read deadline")
 					n, err1 := serverConn.Read(buf)
 					if err1 != nil {
 						log.Printf("Failed: %s", err1)
 						return
 					}
 
-					conn.SetWriteDeadline(time.Now().Add(time.Minute * 30))
+					setWriteDeadlineWithLog(conn, time.Now().Add(30*time.Minute), "failed to set incoming write deadline")
 					_, err1 = conn.Write(buf[:n])
 					if err1 != nil {
 						log.Printf("Failed: %s", err1)


### PR DESCRIPTION
This change makes it possible to run the client on iOS through iSH.

The main issue was TURN client initialization on `linux/386` inside iSH:
`route ip+net: netlinkrib: invalid argument`

To fix this, the client now avoids the network-interface enumeration path used by `pion/turn` and uses a direct `transport.Net` implementation instead.

This MR also fixes `errcheck` issues for `Close` and deadline calls in both `client` and `server`.

## iSH Run Command

```sh
GODEBUG=asyncpreemptoff=1 GOMAXPROCS=1 ./client-linux-386
```