### PR TITLE
Add mipsle support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,12 +115,12 @@ jobs:
             EXT=
           fi
 
-          GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM GOMIPS=$GOMIPS\
+          GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM GOMIPS=$GOMIPS \
           go build -ldflags "-s -w -checklinkname=0" -trimpath \
             -o "dist/client-${GOOS}-${GOARCH}${EXT}" \
             ./client
           
-          GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM GOMIPS=$GOMIPS\
+          GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM GOMIPS=$GOMIPS \
           go build -ldflags "-s -w -checklinkname=0" -trimpath \
             -o "dist/server-${GOOS}-${GOARCH}${EXT}" \
             ./server


### PR DESCRIPTION
Added support for mipsle with GOMIPS=softfloat in GitHub Actions. This allows the binaries to run on popular routers based on the MT7621 chipset and similar MIPS platforms without a hardware FPU.

Добавил поддержку mipsle softfloat для всё ещё популярных роутеров на базе MT7621 и аналогичных MIPS-платформ.