### PR TITLE
don't break route scripts on duplicate TURN IPs

### DIFF
--- a/routes.ps1
+++ b/routes.ps1
@@ -16,12 +16,33 @@ $input | ForEach-Object {
     $addr = $_.Trim()
     if ($addr -eq "") { return }
 
-    Write-Host "Добавляем маршрут к $addr через $gateway"
+    if ($addr -notmatch '^\d{1,3}(\.\d{1,3}){3}$') {
+        Write-Warning "Пропускаем неожиданный ввод: $addr"
+        return
+    }
+
+    $prefix = "$addr/32"
+    $existingRoutes = @(Get-NetRoute `
+        -DestinationPrefix $prefix `
+        -PolicyStore ActiveStore `
+        -ErrorAction SilentlyContinue)
+
+    if ($existingRoutes | Where-Object { $_.NextHop -eq $gateway }) {
+        Write-Host "Маршрут к $addr через $gateway уже существует"
+        return
+    }
+
+    if ($existingRoutes.Count -gt 0) {
+        Write-Host "Обновляем маршрут к $addr через $gateway"
+        $existingRoutes | Remove-NetRoute -Confirm:$false -ErrorAction Stop
+    } else {
+        Write-Host "Добавляем маршрут к $addr через $gateway"
+    }
 
     New-NetRoute `
-        -DestinationPrefix "$addr/32" `
+        -DestinationPrefix $prefix `
         -NextHop $gateway `
         -PolicyStore ActiveStore `
-        -ErrorAction Stop
+        -ErrorAction Stop | Out-Null
 }
 

--- a/routes.sh
+++ b/routes.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
+set -euo pipefail
+
 gateway="$(ip -o -4 route show to default | awk '/via/ {print $3}' | head -1)"
-while read -r remote; do
-  sudo ip r add $remote via $gateway
+if [[ -z "${gateway}" ]]; then
+  echo "Could not determine default gateway" >&2
+  exit 1
+fi
+
+ip_cmd=(ip)
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  ip_cmd=(sudo ip)
+fi
+
+while IFS= read -r remote; do
+  remote="${remote%$'\r'}"
+  [[ -z "$remote" ]] && continue
+
+  if [[ ! "$remote" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    echo "Skipping unexpected input: $remote" >&2
+    continue
+  fi
+
+  echo "Ensuring route to $remote via $gateway"
+  "${ip_cmd[@]}" route replace "$remote" via "$gateway"
 done


### PR DESCRIPTION
Repeated TURN IPs are normal here because the client can print the same address more than once, especially with VK's default parallel connections.

What changed:
- Linux route script now uses ip route replace instead of failing on duplicate entries
- both scripts skip junk / non-IP lines from stdin
- Windows script reuses an existing /32 route when the next hop is already correct

This makes reruns of client | routes.* much less fragile.