### PR TITLE
fix(#129): manual captcha solving

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -908,11 +908,6 @@ func getTokenChain(ctx context.Context, link string, streamID int, creds VKCrede
 
 	var token2 string
 	for attempt := 0; ; attempt++ {
-		solveMode, hasSolveMode := captchaSolveModeForAttempt(attempt, manualCaptcha, autoCaptchaSliderPOC)
-		if !hasSolveMode {
-			break
-		}
-
 		resp, err = doRequest(data, urlAddr)
 		if err != nil {
 			return "", "", "", err
@@ -921,6 +916,21 @@ func getTokenChain(ctx context.Context, link string, streamID int, creds VKCrede
 		if errObj, hasErr := resp["error"].(map[string]interface{}); hasErr {
 			captchaErr := ParseVkCaptchaError(errObj)
 			if captchaErr != nil && captchaErr.IsCaptchaError() {
+				solveMode, hasSolveMode := captchaSolveModeForAttempt(attempt, manualCaptcha, autoCaptchaSliderPOC)
+				if !hasSolveMode {
+					log.Printf("[STREAM %d] [Captcha] No more solve modes available (attempt %d)", streamID, attempt+1)
+
+					// Engage global lockout to protect API
+					globalCaptchaLockout.Store(time.Now().Add(60 * time.Second).Unix())
+
+					if connectedStreams.Load() == 0 {
+						log.Printf("[STREAM %d] [FATAL] 0 connected streams and captcha solve modes exhausted.", streamID)
+						return "", "", "", fmt.Errorf("FATAL_CAPTCHA_FAILED_NO_STREAMS")
+					}
+
+					return "", "", "", fmt.Errorf("CAPTCHA_WAIT_REQUIRED")
+				}
+
 				var successToken string
 				var captchaKey string
 				var solveErr error

--- a/client/main.go
+++ b/client/main.go
@@ -2195,6 +2195,7 @@ func createSmuxSession(ctx context.Context, tp *turnParams, peer *net.UDPAddr, i
 		STUNServerAddr:         turnServerAddr,
 		TURNServerAddr:         turnServerAddr,
 		Conn:                   turnConn,
+		Net:                    newDirectNet(),
 		Username:               user,
 		Password:               pass,
 		RequestedAddressFamily: addrFamily,


### PR DESCRIPTION
проблема с ручным прохождением капчи: https://github.com/cacggghp/vk-turn-proxy/issues/129
```
==============================================
ACTION REQUIRED: MANUAL CAPTCHA SOLVING NEEDED
Open this URL in your browser: http://localhost:8765
==============================================

2026/04/09 08:15:50 [STREAM 1] [VK Auth] Failed with client_id=6287487: missing turn_server in response: map[error_code:457 error_data:<nil> error_msg:UNAUTHORIZED_RESTRICTION : Authorized session or anonymToken required]
2026/04/09 08:15:50 [STREAM 1] [VK Auth] Trying credentials: client_id=7879029
2026/04/09 08:15:50 [STREAM 1] [VK Auth] Connecting Identity - Name: Ирина Захарова | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/[146.0.0.0](https://146.0.0.0/) Safari/537.36
2026/04/09 08:15:52 [STREAM 1] [Captcha] Triggering manual captcha fallback...

==============================================
ACTION REQUIRED: MANUAL CAPTCHA SOLVING NEEDED
Open this URL in your browser: http://localhost:8765
==============================================
```

Что сделано:
убрал преждевременную проверку hasSolveMode в начале каждой итерации цикла token2. Теперь:                                                                                                                            

 1. doRequest всегда выполняется первым на каждой итерации (включая повтор после успешно решённой капчи).
 2. Проверка hasSolveMode перенесена внутрь ветки обработки captcha-ошибки — она блокирует только новые попытки решения, а не повтор запроса с уже полученным success_token.                                                       
 3. Когда режимы решения исчерпаны, корректно срабатывает global lockout + CAPTCHA_WAIT_REQUIRED (тот же путь, что и при solveErr != nil ниже).  