### PR TITLE
server: add ping/pong echo capability (enables optional client-side liveness checks)

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -169,6 +169,33 @@ func handleUDPConnection(ctx context.Context, conn net.Conn, connectAddr string)
 				return
 			}
 
+			// Liveness-probe echo. Clients may send short sentinel
+			// packets (4-byte magic 0xff 'P' 'N' 'G' + payload)
+			// periodically over a DTLS conn to detect data-path
+			// failures that don't show up at the control plane —
+			// e.g. TURN allocations where Refresh/keepalive succeed
+			// but the relay's NAT mapping is stale and packets are
+			// silently dropped. We echo the bytes back through the
+			// same DTLS conn — pion's dtls.Conn is goroutine-safe so
+			// concurrent Write from this read-loop and the WG-receive
+			// loop below is fine. The first byte 0xff falls outside
+			// WireGuard's 1..4 message types, so without this branch
+			// the bytes would be forwarded to serverConn (WG) and
+			// silently dropped — which is also what unpatched servers
+			// do, hence clients sending probes to an unpatched server
+			// see no echo and degrade gracefully.
+			if n >= 4 && buf[0] == 0xff && buf[1] == 'P' && buf[2] == 'N' && buf[3] == 'G' {
+				if err1 := conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err1 != nil {
+					log.Printf("Failed to set probe-echo deadline: %s", err1)
+					return
+				}
+				if _, err1 := conn.Write(buf[:n]); err1 != nil {
+					log.Printf("Failed to echo probe: %s", err1)
+					return
+				}
+				continue
+			}
+
 			if err1 = serverConn.SetWriteDeadline(time.Now().Add(time.Minute * 30)); err1 != nil {
 				log.Printf("Failed: %s", err1)
 				return


### PR DESCRIPTION
## Summary

Adds a small server-side capability: when a DTLS payload starts with the 4-byte magic prefix `0xff 'P' 'N' 'G'`, the server echoes the entire packet back to the client through the same DTLS conn. Otherwise the packet is forwarded to WireGuard as before.

That's the entire change — 27 lines in `server/main.go`. The server now answers a simple ping. Whether any client *uses* this capability is up to the client.

## Backward compatibility

The echo branch is gated on the magic-prefix check. Without that prefix nothing fires — every existing client sees identical behaviour.

| Combination | Behaviour |
|-------------|-----------|
| Old client + old server | unchanged |
| Old client + **new server** | unchanged (clients never send the magic) |
| New client + old server | clients see no echo and degrade gracefully (their probe path is dormant); the bytes flow through to WG which drops them as invalid message type `0xff` (outside WG's 1..4 range), no log spam |
| New client + new server | clients can use the echo for whatever they want |

The patch only enables a new capability. Nothing existing changes.

## Why

Real use case that prompted this: clients that need to detect *zombie* TURN allocations — sessions where pion's `Refresh` and VK's NAT-keepalive `Binding` both succeed, so control plane signals "healthy", but the actual data path through VK's relay is broken (typically because the client's NAT mapping shifted after a network handover and VK's relay state is now stale).

Without an end-to-end signal, the client has no way to tell. With the ping/pong capability, the client can periodically send a ping and watch for the echo; absence of echoes for a configurable threshold means the data path is dead and the conn should be torn down regardless of what the control plane says.

The point of putting this in the server (rather than the client only) is that the data-path health check has to be *end-to-end*. Anything the client measures on its own (TURN refresh, STUN binding, etc.) can be healthy while the VK relay is silently dropping payloads.

## Cost

Trivial. One byte-prefix comparison per inbound DTLS packet (no allocation, no parsing). When echoing, one DTLS write per ping. With 30 conns at 30s ping interval that's ~1 packet/sec total across all clients combined.

The wire-level overhead is borne by the client (the entity choosing to ping); the server only echoes what arrives.

## Reference client implementation (informational)

For maintainers curious how a client would use this capability, the iOS client at [`anton48/vk-turn-proxy-ios`](https://github.com/anton48/vk-turn-proxy-ios) implements it in commit [`8c430f3`](https://github.com/anton48/vk-turn-proxy-ios/commit/8c430f33940b22acc6b587cb94fad46b40dd3649) (141 lines in `pkg/proxy/proxy.go`, which is a refactored extraction of `client/main.go`). Empirically settled on, after a month of iteration in production:

- 12-byte ping: 4-byte magic + 8-byte sequence
- 30s send interval, 120s stale threshold (4 missed echoes)
- A global "server is echoing" flag latched on first received echo, so clients never kill conns when talking to an unpatched server

That's all reference — not part of what this PR proposes for upstream. A direct port to upstream's `oneDtlsConnectionLoop` / `oneTurnConnection` architecture would be a separate PR if there's interest, but the server capability stands on its own and any other client (mobile, desktop, embedded) can use it however they want.

## Empirical motivation

`vpn.wifi-lte-wifi.0.log` from the iOS port on 2026-04-29 (30 conns): after a single LTE→WiFi handover, 28/30 conns reported "active" but throughput collapsed to ~35% packet loss. Manual reconnect from scratch immediately gave 30/30 with 0% loss. Control-plane signals all said "healthy" the whole time. Adding the probe-and-kill loop on the iOS side made the recovery automatic — within ~120s of the handover the zombie conns are killed and rebuilt with fresh allocations.

## Notes

- Magic bytes (`0xff 'P' 'N' 'G'`) are arbitrary — happy to change to whatever convention the project prefers.
- Verified: `go build` and `go vet` clean, `gofmt` clean.